### PR TITLE
First version of getEurostatRCV with tidyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,10 +10,10 @@ Description: Eurostat Open Data R Tools
 License: BSD_2_clause + file LICENSE
 Depends:
     R (>= 3.0.2),
-    reshape,
     statfi,
     pxR,
-    plyr
+    plyr,
+    tidyr    
 Suggests:
     countrycode,
     mapproj,

--- a/R/getEurostatRCV.R
+++ b/R/getEurostatRCV.R
@@ -12,12 +12,12 @@
 #' Returns:
 #'  @return A dataset in the molten format with the last column 'value'. See the melt function from reshape package for more details.
 #'
-#' @importFrom reshape melt
+#' @import tidyr
 #' @export
 #' @seealso \code{\link{getEurostatTOC}}, \code{\link{getEurostatRaw}}, \code{\link{grepEurostatTOC}}
 #' @details Data is downloaded from \code{http://epp.eurostat.ec.europa.eu/NavTree_prod/everybody/BulkDownloadListing} website.
 #' @references see citation("eurostat"). 
-#' @author Przemyslaw Biecek and Leo Lahti \email{louhos@@googlegroups.com}
+#' @author Przemyslaw Biecek, Leo Lahti \email{louhos@@googlegroups.com} and Janne Huovari \email{janne.huovari@ptt.fi}
 #' @examples \dontrun{
 #'    tmp <- getEurostatRCV(kod = "educ_iste")
 #'    head(tmp)
@@ -34,19 +34,16 @@
 #' @keywords utilities database
 
 getEurostatRCV <-
-function(kod = "educ_iste") {
-
-  dat <- getEurostatRaw(kod)
-  dat2 <- t(as.data.frame(strsplit(as.character(dat[,1]), split=",")))
-  cnames <- strsplit(colnames(dat)[1], split="[,\\\\]")[[1]]
-  colnames(dat2) <- cnames[-length(cnames)]
-  rownames(dat2) <- dat[,1]
-  rownames(dat) <- dat[,1]
-  dat3 <- data.frame(dat2, dat[,-1])
-  colnames(dat3) <- c(colnames(dat2), colnames(dat)[-1])
-  dat4 <- melt(dat3, id=cnames[-length(cnames)])
-  colnames(dat4)[ncol(dat4)-1] = cnames[length(cnames)]
-
-  dat4
-
-}
+  function(kod = "educ_iste") {
+    
+    dat <- getEurostatRaw(kod)
+    cnames <- strsplit(colnames(dat)[1], split="[,\\\\]")[[1]]
+    cnames1 <- cnames[-length(cnames)]
+    cnames2 <- cnames[length(cnames)]
+    names(dat)[1] <- "varcol"
+    dat2 <- tidyr::separate(dat, col = varcol, 
+                       into = cnames1, 
+                       sep = ",", convert = TRUE)
+    dat3 <- tidyr::gather_(dat2, cnames2, "value", names(dat2)[-c(1:length(cnames1))])
+    dat3
+  }


### PR DESCRIPTION
Rewrote getEurostatRCV with tidyr

I tried a new tidyr package for getEurostatRCV and replaced the previously used melt from 
reshape package. The speed improved is sizable. With “avia_goincc” data the system.time() gives 
with reshape:
   user  system elapsed 
  59.52   10.15   70.41

with tidyr:
   user  system elapsed 
   0.05    0.00    0.05 

Improved is probably due to dplyr that tidyr uses. Could be used also to getEurostatRaw?

The data.frame that the modified function returns is bit different from previous version. Variable columns 
no longer have (row)names. It think that was duplication of information and output of str() from 
that data.frame was confusing and hard to read.

Ideas:
getEurostatRCV is long and hard to remember. Better get_eurostat and make getEurostatRaw internal? 
or only eurostat and remove existing eurostat-function? is stat fin version really needed?

If you accept the idea on using tidyr, mayby you should anyway merge it to some development branch, as modification will change the return value and is not tested that much.
