### PR TITLE
tidyr version of the getEurostatRaw

### DIFF
--- a/R/getEurostatRaw.R
+++ b/R/getEurostatRaw.R
@@ -16,7 +16,7 @@
 #' @seealso \code{\link{getEurostatTOC}}, \code{\link{getEurostatRaw}}, \code{\link{grepEurostatTOC}}.
 #' @details Data is downloaded from \code{http://epp.eurostat.ec.europa.eu/NavTree_prod/everybody/BulkDownloadListing} website.
 #' @references see citation("eurostat"). 
-#' @author Przemyslaw Biecek and Leo Lahti \email{louhos@@googlegroups.com}
+#' @author Przemyslaw Biecek, Leo Lahti \email{louhos@@googlegroups.com} and Janne Huovari \email{janne.huovari@ptt.fi}
 #' @examples \dontrun{
 #' 	       tmp <- getEurostatRaw(kod = "educ_iste")
 #' 	       head(tmp)
@@ -38,9 +38,7 @@ function(kod = "educ_iste") {
 
   #  remove additional marks
   for (i in 2:ncol(dat)) {
-    tmp <- sapply(strsplit(as.character(dat[,i]), split = ' '), `[`, 1)
-    tmp[tmp==":"] = NA
-    dat[,i] <-as.numeric(tmp)
+    dat[,i] <- extract_numeric(dat[,i])
   }
   dat
 }


### PR DESCRIPTION
I just noticed extract_numeric in tidyr and couldn't resist. It's faster than original.

Other comments: I think header = F in read.table and then manually giving column names that are not legal column names is not good idea. Better change them in getEurostatRCV. And mayby change them to dates? Or at least option to change them to dates?
