### PR TITLE
eurotime2date: avoid warning when time variable is a year interval

### DIFF
--- a/R/eurotime2date.R
+++ b/R/eurotime2date.R
@@ -36,6 +36,7 @@ eurotime2date <- function(x, last = FALSE){
   if (tcode == "") tcode <- "Y"
   
   day <- "01"    # default for day
+  
   # for yearly data
   if (tcode == "Y") {
     period <- "01"
@@ -56,10 +57,12 @@ eurotime2date <- function(x, last = FALSE){
     day <- gsub("D", "", days)
   # for year intervals
   } else if (tcode == "_") {
+    warning("Time format is a year interval. No date conversion was made.")
     return(x)
   # for unkown
   } else {
-    warning("Unknown time code, ", tcode, ". No date conversion was made.\nPlease fill bug report at https://github.com/rOpenGov/eurostat/issues.")
+    warning("Unknown time code, ", tcode, ". No date conversion was made.\n
+            Please fill bug report at https://github.com/rOpenGov/eurostat/issues.")
     return(x)
   }
   

--- a/R/eurotime2date.R
+++ b/R/eurotime2date.R
@@ -28,7 +28,7 @@ eurotime2date <- function(x, last = FALSE){
   year <- substr(times, 1, 4)
   subyear <- substr(times, 5, 7)
   tcode <- substr(subyear[1], 1, 1)  # type of time data
-  if (nchar(times[1]) > 7){
+  if (tcode != "_" && nchar(times[1]) > 7){
     days <- substr(times, 8, 10)
     tcode <- substr(days[1], 1, 1)  # type of time data if daily
   }
@@ -37,23 +37,26 @@ eurotime2date <- function(x, last = FALSE){
   
   day <- "01"    # default for day
   # for yearly data
-  if (tcode == "Y"){          
+  if (tcode == "Y") {
     period <- "01"
     # for bi-annual
-  } else if (tcode == "S"){
+  } else if (tcode == "S") {
     lookup <- c(S1 = "01", S2 = "07")
     period <- lookup[subyear] 
   # for quarterly
-  } else if (tcode == "Q"){
+  } else if (tcode == "Q") {
     lookup <- c(Q1 = "01", Q2 = "04", Q3 = "07", Q4 = "10")
     period <- lookup[subyear] 
   # for montly
-  } else if (tcode == "M"){
+  } else if (tcode == "M") {
     period <- gsub("M", "", subyear)
   # for daily
-  } else if (tcode == "D"){
+  } else if (tcode == "D") {
     period <- gsub("M", "", subyear)
     day <- gsub("D", "", days)
+  # for year intervals
+  } else if (tcode == "_") {
+    return(x)
   # for unkown
   } else {
     warning("Unknown time code, ", tcode, ". No date conversion was made.\nPlease fill bug report at https://github.com/rOpenGov/eurostat/issues.")

--- a/R/eurotime2num.R
+++ b/R/eurotime2num.R
@@ -34,13 +34,18 @@ eurotime2num <- function(x){
 
   
   # check input type  
-  if (!(tcode %in% c("Y", "S", "Q", "M"))) {
+  if (!(tcode %in% c("Y", "S", "Q", "M", "_"))) {
+
+    # for daily
     if (tcode == "D"){
-      warning("For daily data there is not a numeric conversion available. 
-              No conversion made.")
+      warning("Time format is daily data. No numeric conversion was made.")
+    # for year intervals
+    } else if (tcode == "_") {
+      warning("Time format is a year interval. No numeric conversion was made.")
+    # for unkown
     } else {
-      warning("Unknown time code, ", tcode, ". No date conversion was made.
-            \nPlease fill bug report at https://github.com/rOpenGov/eurostat/issues.")
+      warning("Unknown time code, ", tcode, ". No numeric conversion was made.\n
+              Please fill bug report at https://github.com/rOpenGov/eurostat/issues.")
     }
     
     return(x)   

--- a/R/get_eurostat.R
+++ b/R/get_eurostat.R
@@ -18,8 +18,8 @@
 #'    select one of them with: Y = annual, S = semi-annual, Q = quarterly, M = monthly. 
 #'    For all frequencies in same data.frame \code{time_format = "raw"} 
 #'    should be used. 
-#' @param cache a logical wheather to do caching. Default is \code{TRUE}.
-#' @param update_cache a locigal wheater to update cache. Can be set also with
+#' @param cache a logical whether to do caching. Default is \code{TRUE}.
+#' @param update_cache a locigal whether to update cache. Can be set also with
 #' 	  options(eurostat_update = TRUE)
 #' @param cache_dir a path to a cache directory. The directory have to exist.
 #'    The \code{NULL} (default) uses and creates 

--- a/R/get_eurostat_dic.R
+++ b/R/get_eurostat_dic.R
@@ -29,9 +29,9 @@ function(dictname) {
   url <- eurostat_url()		   
   read.table(paste(url, 
    "estat-navtree-portlet-prod/BulkDownloadListing?file=dic%2Fen%2F",
-   dictname, ".dic", sep=""),
-   sep="\t", header=F, stringsAsFactors=FALSE, quote = "\"",
-   fileEncoding="Windows-1252")
+   dictname, ".dic", sep = ""),
+   sep = "\t", header = FALSE, stringsAsFactors = FALSE, quote = "\"",
+   fileEncoding = "Windows-1252")
 }
 
 #' @describeIn get_eurostat_dic Old deprecated version

--- a/R/get_eurostat_raw.R
+++ b/R/get_eurostat_raw.R
@@ -28,14 +28,14 @@ get_eurostat_raw <- function(id) {
 
   url <- paste(base, 
     "estat-navtree-portlet-prod/BulkDownloadListing?sort=1&file=data%2F",
-    id, ".tsv.gz", sep="")
+    id, ".tsv.gz", sep = "")
 
   tfile <- tempfile()
   on.exit(unlink(tfile))
   
   # download and read file
   download.file(url, tfile)
-  dat <- read.table(gzfile(tfile), sep="\t", na.strings = ": ", 
+  dat <- read.table(gzfile(tfile), sep = "\t", na.strings = ": ", 
                     header = TRUE, stringsAsFactors = FALSE)
   # check validity
   if (ncol(dat) < 2 | nrow(dat) < 1) {

--- a/R/get_eurostat_toc.R
+++ b/R/get_eurostat_toc.R
@@ -22,7 +22,7 @@ get_eurostat_toc <- function() {
   invisible(get(".eurostatTOC", envir = .EurostatEnv))
 }
 
-#' @describeIn get_eurostat_toc Old depricated version
+#' @describeIn get_eurostat_toc Old deprecated version
 #' @export
 getEurostatTOC <- function() {
   .Deprecated("get_eurostat_toc")

--- a/R/search_eurostat.R
+++ b/R/search_eurostat.R
@@ -28,12 +28,12 @@
 search_eurostat <- function(pattern, type = "dataset") {
   set_eurostat_toc()
   tmp <- get(".eurostatTOC", envir = .EurostatEnv)
-  if (type != "all") tmp <- tmp[tmp[, "type"] %in% type,]
-  tmp[grep(as.character(tmp[, "title"]), pattern=pattern),]
+  if (type != "all") tmp <- tmp[ tmp[, "type"] %in% type, ]
+  tmp[ grep(as.character(tmp[, "title"]), pattern = pattern), ]
 }
 
 
-#' @describeIn search_eurostat Old depricated version
+#' @describeIn search_eurostat Old deprecated version
 #' @export
 grepEurostatTOC <- function(pattern, type = "dataset"){
   .Deprecated("search_eurostat")

--- a/R/set_eurostat_toc.R
+++ b/R/set_eurostat_toc.R
@@ -15,8 +15,8 @@ set_eurostat_toc <- function() {
    url <- paste(base, "estat-navtree-portlet-prod/", 
        	 "BulkDownloadListing?sort=1&downfile=table_of_contents_en.txt", 
 	 sep = "")
-   .eurostatTOC <-  read.table(file = url, sep="\t", header=T, quote="\"", 
-   		    	        fill = TRUE, comment.char = "", stringsAsFactors = FALSE)
+   .eurostatTOC <- read.table(file = url, sep = "\t", header = TRUE, quote = "\"", 
+                              fill = TRUE, comment.char = "", stringsAsFactors = FALSE)
     assign(".eurostatTOC", .eurostatTOC, envir = .EurostatEnv)
   }
   invisible(0)

--- a/R/tidy_eurostat.R
+++ b/R/tidy_eurostat.R
@@ -26,7 +26,7 @@ tidy_eurostat <-
            stringsAsFactors = default.stringsAsFactors()) {
  
     # Separate codes to columns
-    cnames <- strsplit(colnames(dat)[1], split="\\.")[[1]]
+    cnames <- strsplit(colnames(dat)[1], split = "\\.")[[1]]
     cnames1 <- cnames[-length(cnames)]
     cnames2 <- cnames[length(cnames)]
     dat2 <- tidyr::separate_(dat, col = colnames(dat)[1], 


### PR DESCRIPTION
Hi,

This is a tiny bugfix for `eurotime2date.R` that avoids printing a warning when the `time` variable of a dataset is a year interval of the form `2006_2008`. The code now simply skips it.

Perhaps the same kind of fix should be applied to `eurotime2num.R` too.