### PR TITLE
Use https in the eurostat URL

### DIFF
--- a/R/eurostat_url.R
+++ b/R/eurostat_url.R
@@ -6,5 +6,5 @@
 #' @author Leo Lahti \email{leo.lahti@iki.fi}
 #' @keywords internal
 eurostat_url <- function(...) {
-  "http://ec.europa.eu/eurostat/"
+  "https://ec.europa.eu/eurostat/"
 }


### PR DESCRIPTION
http is not available any more, Eurostat now forces the use https for file download.