### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/get_eurostat_geospatial.R
+++ b/R/get_eurostat_geospatial.R
@@ -158,7 +158,7 @@ Please check your connection and/or review your proxy settings")
   
     if (nuts_level %in% c("0","all")){
       url <- paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_0.geojson")
-      resp <- GET(url)
+      resp <- RETRY("GET", url, terminate_on = c(404))
       if (httr::http_error(resp)) { 
         stop(paste("The requested url cannot be found within the get_eurostat_geospatial function:", url))
       } else {
@@ -168,7 +168,7 @@ Please check your connection and/or review your proxy settings")
     }
     if (nuts_level %in% c("1","all")){
       url <- paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_1.geojson")
-      resp <- GET(url)
+      resp <- RETRY("GET", url, terminate_on = c(404))
       if (httr::http_error(resp)) {
         stop(paste("The requested url cannot be found within the get_eurostat_geospatial function:", url))
       } else {
@@ -177,7 +177,7 @@ Please check your connection and/or review your proxy settings")
         }
     }    
     if (nuts_level %in% c("2","all")){
-      resp <- GET(paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_2.geojson"))
+      resp <- RETRY("GET", paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_2.geojson"), terminate_on = c(404))
       if (httr::http_error(resp)) { 
         stop(paste("The requested url cannot be found within the get_eurostat_geospatial function:", url))
       } else {
@@ -186,7 +186,7 @@ Please check your connection and/or review your proxy settings")
         }
     }
     if (nuts_level %in% c("3","all")){
-      resp <- GET(paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_3.geojson"))
+      resp <- RETRY("GET", paste0("http://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/geojson/NUTS_RG_",resolution,"M_",year,"_4326_LEVL_3.geojson"), terminate_on = c(404))
       if (httr::http_error(resp)) { 
         stop(paste("The requested url cannot be found within the get_eurostat_geospatial function:", url))
       } else {

--- a/R/get_eurostat_json.R
+++ b/R/get_eurostat_json.R
@@ -68,7 +68,7 @@ get_eurostat_json <- function(id, filters = NULL,
   
     # resp <- try(httr::GET(url, ...))
     # if (class(resp) == "try-error") { stop(paste("The requested url cannot be found within the get_eurostat_json function:", url))  }
-    resp <- httr::GET(url)
+    resp <- httr::RETRY("GET", url, terminate_on = c(404))
     if (httr::http_error(resp)) { 
       stop(paste("The requested url cannot be found within the get_eurostat_json function:", url))
     }


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.