### PR TITLE
Fix typos and cache is crs-aware & man updated

### DIFF
--- a/R/get_eurostat_geospatial.R
+++ b/R/get_eurostat_geospatial.R
@@ -161,7 +161,7 @@ Please check your connection and/or review your proxy settings")
     cache_file <- file.path(cache_dir,
                             paste0(
                               output_class, resolution, 
-                              nuts_level, year, ".RData")
+                              nuts_level, year, crs, ".RData")
     )
   }
   
@@ -229,20 +229,20 @@ Please check your connection and/or review your proxy settings")
   }
   }
 
-  if (resolution != "60" & year != "2016"){
-  if (cache & file.exists(cache_file)) {
-    cf <- path.expand(cache_file)
-    message(paste("Reading cache file", cf))
-    load(file = cache_file)
-    if (output_class == "sf") message(paste("sf at resolution 1:", 
+  if (!(resolution == "60" & year == "2016" & crs == "4326")){
+    if (cache & file.exists(cache_file)) {
+      cf <- path.expand(cache_file)
+      message(paste("Reading cache file", cf))
+      load(file = cache_file)
+      if (output_class == "sf") message(paste("sf at resolution 1:", 
                                             resolution, " from year ",
                                             year," read from cache file: ",
                                             cf))
-    if (output_class == "df") message(paste("data_frame at resolution 1:",
+      if (output_class == "df") message(paste("data_frame at resolution 1:",
                                             resolution, " from year ", 
                                             year," read from cache file: ", 
                                             cf))
-    if (output_class == "spdf") message(paste("SpatialPolygonDataFrame at resolution 1:", 
+      if (output_class == "spdf") message(paste("SpatialPolygonDataFrame at resolution 1:", 
                                               resolution, " from year ", 
                                               year," read from cache file: ",
                                               cf))

--- a/R/get_eurostat_geospatial.R
+++ b/R/get_eurostat_geospatial.R
@@ -17,7 +17,7 @@
 #'    "2003", "2006", "2010", "2013", "2016" or "2021"
 #' @param cache a logical whether to do caching. Default is \code{TRUE}. Affects 
 #'        only queries from the bulk download facility.
-#' @param update_cache a locigal whether to update cache. Can be set also with
+#' @param update_cache a logical whether to update cache. Can be set also with
 #'        options(eurostat_update = TRUE)
 #' @param cache_dir a path to a cache directory. The directory have to exist.
 #'        The \code{NULL} (default) uses and creates

--- a/R/get_eurostat_geospatial.R
+++ b/R/get_eurostat_geospatial.R
@@ -113,7 +113,7 @@ Please check your connection and/or review your proxy settings")
 # information regarding their licence agreements.
 #       ")
   
-  if (resolution == "60" && year == 2016 && crs == "4326"){
+  if (resolution == "60" && year == "2016" && crs == "4326"){
     
     if (nuts_level %in% c("all")){
       shp <- eurostat_geodata_60_2016 
@@ -229,7 +229,7 @@ Please check your connection and/or review your proxy settings")
   }
   }
 
-  if (resolution != "60" & year != 2016){
+  if (resolution != "60" & year != "2016"){
   if (cache & file.exists(cache_file)) {
     cf <- path.expand(cache_file)
     message(paste("Reading cache file", cf))

--- a/man/get_eurostat_geospatial.Rd
+++ b/man/get_eurostat_geospatial.Rd
@@ -36,7 +36,7 @@ either \code{sf} \code{simple features}, \code{df} (\code{data_frame}) or
 \item{cache}{a logical whether to do caching. Default is \code{TRUE}. Affects 
 only queries from the bulk download facility.}
 
-\item{update_cache}{a locigal whether to update cache. Can be set also with
+\item{update_cache}{a logical whether to update cache. Can be set also with
 options(eurostat_update = TRUE)}
 
 \item{cache_dir}{a path to a cache directory. The directory have to exist.


### PR DESCRIPTION
Following #189 and #190 

- Fix typo: https://github.com/dieghernan/eurostat/commit/5c7e20590ef3cb0fd4116804e7d49931c6df871a
- Move comparison to `string\string` instead of `string\integer` (now it is `year == "2016"`). Although `string\integer` worked it seems just right to perform the comparison between the same data types: https://github.com/dieghernan/eurostat/commit/f93714b18277b4bebcb1905302ced73c414f5302
- Update for caching, so now it is `crs`-aware. I didn't spotted this one, meaning that `get_eurostat_geospatial(year =2013, crs=4326)` and `get_eurostat_geospatial(year = 2013, crs=3857)` produced the same result (since `4326` was cached in first place and `3857`was updated from cache). Potential workaround is to set `update_cache = FALSE`).