### PR TITLE
Install RefManageR from GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,8 @@ Suggests:
     testthat,
     tmap,
     usethis
+Remotes:
+    ropensci/RefManageR
 LazyData: true
 URL: https://ropengov.github.io/eurostat
 BugReports: https://github.com/ropengov/eurostat/issues


### PR DESCRIPTION
RefMangeR has been archived from CRAN. This means the eurostat package cannot be installed because it's missing the RefManageR package. 