### PR TITLE
New CRAN release (minor fix)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,7 +9,6 @@ index.*
 docs
 
 # Vignette
-#./vignettes/website
 ./vignettes/*.Rmd
 #./vignettes/fig
 #./vignettes/fig/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Tools for Eurostat Open Data
 Version: 3.7.10
 Date: 2022-02-08
 Authors@R: c(
-    person("Leo", "Lahti", , "leo.lahti@iki.fi", role = c("aut", "cre"),
+    person("Leo", "Lahti", "leo.lahti@iki.fi", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5537-637X")),
     person("Janne", "Huovari", role = "aut"),
     person("Markus", "Kainu", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: eurostat
 Title: Tools for Eurostat Open Data
-Version: 3.7.9
-Date: 2021-10-01
+Version: 3.7.10
+Date: 2022-02-08
 Authors@R: c(
     person("Leo", "Lahti", , "leo.lahti@iki.fi", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5537-637X")),
@@ -48,11 +48,13 @@ Imports:
     tibble,
     tidyr
 Suggests:
+    RColorBrewer,
     knitr,
     rmarkdown,
     sf,
     sp,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    remotes
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,2 @@
-Copyright 2014-2021 Leo Lahti, Janne Huovari, Markus Kainu, Przemyslaw Biecek
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+YEAR: 2014-2022
+COPYRIGHT HOLDER: Leo Lahti, Janne Huovari, Markus Kainu, Przemyslaw Biecek

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,7 +87,7 @@ knitr::kable(head(passengers))
 ```
 
 
-See the [Tutorial](https://ropengov.github.io/eurostat/articles/articles/eurostat_tutorial.html) and other resources at the [package homepage](https://ropengov.github.io/eurostat//) for more information and examples.
+See the [Tutorial](https://ropengov.github.io/eurostat/articles/articles/eurostat_tutorial.html) and other resources at the [package homepage](https://ropengov.github.io/eurostat/) for more information and examples.
 
 ### Recommended packages
 
@@ -105,16 +105,15 @@ Contributions are very welcome:
 
 ### Acknowledgements
 
-**Kindly cite this work** as follows: [Leo Lahti](https://github.com/antagomir), Przemyslaw Biecek, Markus Kainu and Janne Huovari. Retrieval and analysis of Eurostat open data with the eurostat package. [R Journal 9(1):385-392, 2017](https://journal.r-project.org/archive/2017/RJ-2017-019/index.html). R package version `r sessionInfo()$otherPkgs$eurostat$Version`. DOI: [10.32614/RJ-2017-019](https://doi.org/10.32614/RJ-2017-019). URL: [https://ropengov.github.io/eurostat/](https://ropengov.github.io/eurostat/)
+**Kindly cite this package** as follows: [Leo Lahti](https://github.com/antagomir), Przemyslaw Biecek, Markus Kainu and Janne Huovari. Retrieval and analysis of Eurostat open data with the eurostat package. [R Journal 9(1):385-392, 2017](https://journal.r-project.org/archive/2017/RJ-2017-019/index.html). R package version `r sessionInfo()$otherPkgs$eurostat$Version`. DOI: [10.32614/RJ-2017-019](https://doi.org/10.32614/RJ-2017-019). URL: [https://ropengov.github.io/eurostat/](https://ropengov.github.io/eurostat/)
 
 We are grateful to all [contributors](https://github.com/ropengov/eurostat/graphs/contributors), including Daniel Antal, Joona Lehtomäki, Francois Briatte, and Oliver Reiter, and for the [Eurostat](https://ec.europa.eu/eurostat/) open data portal! This project is part of [rOpenGov](http://ropengov.org).
-
-
 
 ### Disclaimer
 
 This package is in no way officially related to or endorsed by Eurostat.
 
+When using data retrieved from Eurostat database in your work, please indicate that the data source is Eurostat. If your re-use involves some kind of modification to data or text, please state this clearly to the end user. See Eurostat policy on [copyright and free re-use of data](https://ec.europa.eu/eurostat/about/policies/copyright) for more detailed information and certain exceptions.
 
 [chat-badge]: https://img.shields.io/badge/chat-on%20gitter-46BC99.svg?style=flat-square
 [chat]: https://gitter.im/ropengov/eurostat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/README.md
+++ b/README.md
@@ -96,15 +96,15 @@ knitr::kable(head(passengers))
 | Air passenger transport                                            | enps\_avia\_pa  | dataset | 16.04.2021          | NA                          | 2005       | 2020     | NA     |
 | Volume of passenger transport relative to GDP                      | tran\_hv\_pstra | dataset | 07.07.2021          | 07.07.2021                  | 1990       | 2019     | NA     |
 | Modal split of passenger transport                                 | tran\_hv\_psmod | dataset | 07.07.2021          | 07.07.2021                  | 1990       | 2019     | NA     |
-| Air passenger transport by reporting country                       | avia\_paoc      | dataset | 04.10.2021          | 01.10.2021                  | 1993       | 2021Q2   | NA     |
-| Air passenger transport by main airports in each reporting country | avia\_paoa      | dataset | 07.10.2021          | 01.10.2021                  | 1993       | 2021Q2   | NA     |
-| Air passenger transport between reporting countries                | avia\_paocc     | dataset | 01.10.2021          | 01.10.2021                  | 1993       | 2021Q2   | NA     |
+| Air passenger transport by reporting country                       | avia\_paoc      | dataset | 02.02.2022          | 17.01.2022                  | 1993       | 2021Q3   | NA     |
+| Air passenger transport by main airports in each reporting country | avia\_paoa      | dataset | 01.02.2022          | 01.02.2022                  | 1993       | 2021Q4   | NA     |
+| Air passenger transport between reporting countries                | avia\_paocc     | dataset | 02.02.2022          | 17.01.2022                  | 1993       | 2021Q3   | NA     |
 
 See the
 [Tutorial](https://ropengov.github.io/eurostat/articles/articles/eurostat_tutorial.html)
 and other resources at the [package
-homepage](https://ropengov.github.io/eurostat//) for more information
-and examples.
+homepage](https://ropengov.github.io/eurostat/) for more information and
+examples.
 
 ### Recommended packages
 
@@ -125,12 +125,12 @@ Contributions are very welcome:
 
 ### Acknowledgements
 
-**Kindly cite this work** as follows: [Leo
+**Kindly cite this package** as follows: [Leo
 Lahti](https://github.com/antagomir), Przemyslaw Biecek, Markus Kainu
 and Janne Huovari. Retrieval and analysis of Eurostat open data with the
 eurostat package. [R
 Journal 9(1):385-392, 2017](https://journal.r-project.org/archive/2017/RJ-2017-019/index.html).
-R package version 3.7.9. DOI:
+R package version 3.7.10. DOI:
 [10.32614/RJ-2017-019](https://doi.org/10.32614/RJ-2017-019). URL:
 <https://ropengov.github.io/eurostat/>
 
@@ -143,6 +143,13 @@ portal\! This project is part of [rOpenGov](http://ropengov.org).
 ### Disclaimer
 
 This package is in no way officially related to or endorsed by Eurostat.
+
+When using data retrieved from Eurostat database in your work, please
+indicate that the data source is Eurostat. If your re-use involves some
+kind of modification to data or text, please state this clearly to the
+end user. See Eurostat policy on [copyright and free re-use of
+data](https://ec.europa.eu/eurostat/about/policies/copyright) for more
+detailed information and certain exceptions.
 
 <!--[build-badge]: https://img.shields.io/travis/ropengov/eurostat.svg?style=flat-square-->
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,15 +1,14 @@
+citHeader("Kindly cite the eurostat R package as follows:")
+
 note <- sprintf("Version %s", meta$Version)
 
 bibentry("Article",
-  header = "Kindly cite the eurostat R package as follows:",
-  title = "Retrieval and Analysis of Eurostat Open Data with the
-           eurostat Package",
+  title = "Retrieval and Analysis of Eurostat Open Data with the eurostat Package",
   author = c(
-    person("Leo", "Lahti"), person("Janne", "Huovari"),
-    person("Markus", "Kainu"), person(
-      "Przemyslaw",
-      "Biecek"
-    )
+    person("Leo", "Lahti"), 
+    person("Janne", "Huovari"),
+    person("Markus", "Kainu"), 
+    person("Przemyslaw", "Biecek")
   ),
   journal = "The R Journal",
   volume = 9,
@@ -18,11 +17,9 @@ bibentry("Article",
   year = "2017",
   doi = "10.32614/RJ-2017-019",
   url = "https://doi.org/10.32614/RJ-2017-019",
-  note = note,
   textVersion =
     paste("(C) Leo Lahti, Janne Huovari, Markus Kainu, Przemyslaw Biecek.",
       "Retrieval and analysis of Eurostat open data with the eurostat package. R Journal 9(1):385-392, 2017.",
-      note,
       "doi: 10.32614/RJ-2017-019",
       "Package URL: http://ropengov.github.io/eurostat",
       "Article URL: https://journal.r-project.org/archive/2017/RJ-2017-019/index.html",

--- a/vignettes/articles/blogposts.Rmd
+++ b/vignettes/articles/blogposts.Rmd
@@ -1,19 +1,21 @@
 ---
 title: "Blog posts"
-date: "`r Sys.Date()`"
-output: 
-  rmarkdown::html_vignette:
-    toc: true
+date: "2022-02-07"
+output: rmarkdown::html_vignette
 vignette: >
     %\VignetteIndexEntry{Blog posts}
     %\VignetteEngine{knitr::rmarkdown}
-    %\VignetteDepends{Cairo}
     %\VignetteEncoding{UTF-8}
-    \usepackage[utf8]{inputenc}    
 ---
 
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
 
- * [Package release](https://rpubs.com/muuankarski/27120)
+Here are some blog posts where eurostat package has been featured. If you have used eurostat package in your workflow and you would like to be included on this list, please let us know!
+
+ * [Package release](https://rpubs.com/muuankarski/27119)
  * [Interactive widgets](https://www.mytinyshinys.com/2017/07/11/eurostat/) by Andrew Clark
- * [Case studies](http://ropengov.github.io/r/2015/05/01/eurostat-package-examples/)
- 

--- a/vignettes/articles/cheatsheet.Rmd
+++ b/vignettes/articles/cheatsheet.Rmd
@@ -1,22 +1,20 @@
 ---
 title: "Cheat sheet: eurostat R package"
-date: "`r Sys.Date()`"
-output:
-  rmarkdown::html_vignette:
-    toc: true
+date: "2022-02-07"
+output: rmarkdown::html_vignette
 vignette: >
     %\VignetteIndexEntry{Cheat sheet: eurostat R package}
     %\VignetteEngine{knitr::rmarkdown}
-    %\VignetteDepends{Cairo}
     %\VignetteEncoding{UTF-8}
-    \usepackage[utf8]{inputenc}        
 ---
 
- * [eurostat R package: cheat sheet (RStudio release version)](https://github.com/rstudio/cheatsheets/raw/master/eurostat.pdf)
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+ * [eurostat R package: cheat sheet (RStudio release version)](https://github.com/rstudio/cheatsheets/blob/main/eurostat.pdf)
 
  * [eurostat R package: cheat sheet (rOpenGov development version)](https://github.com/rOpenGov/eurostat/blob/master/inst/extras/cheatsheet/eurostat_cheatsheet.pdf)
-
-
-
-
-

--- a/vignettes/articles/eurostat_tutorial.Rmd
+++ b/vignettes/articles/eurostat_tutorial.Rmd
@@ -11,7 +11,7 @@ vignette: >
     \usepackage[utf8]{inputenc}
     %\VignetteEngine{knitr::rmarkdown}
 editor_options:
-    chunk_output_type: console
+    chunk_output_type: inline
 ---
 
 # R Tools for Eurostat Open Data
@@ -35,8 +35,8 @@ install.packages("eurostat")
 Development version [(Github)](https://github.com/rOpenGov/eurostat):
 
 ```{r install2, eval=FALSE}
-library(devtools)
-install_github("ropengov/eurostat")
+library(remotes)
+remotes::install_github("ropengov/eurostat")
 ```
 
 ```{r, echo=FALSE}
@@ -62,18 +62,18 @@ Function `get_eurostat_toc()` downloads a table of contents of eurostat datasets
 ```{r get_eurostat_toc, warning=FALSE, message=FALSE, eval = evaluate}
 # Load the package
 library(eurostat)
-library(rvest)
+# library(rvest)
 
 # Get Eurostat data listing
 toc <- get_eurostat_toc()
 
 # Check the first items
 library(knitr)
-kable(head(toc))
+kable(tail(toc))
 ```
 
 Some of the data sets (e.g. in the 'comext' type) are not accessible
-through the standard interface. See the get\_eurostat function documentation for more details.
+through the standard interface. See the `get_eurostat()` function documentation for more details.
 
 With `search_eurostat()` you can search the table of contents for particular patterns, e.g. all datasets related to *passenger transport*. The kable function to produces nice markdown output. Note that with the `type` argument of this function you could restrict the search to for instance datasets or tables.
 

--- a/vignettes/articles/maps.Rmd
+++ b/vignettes/articles/maps.Rmd
@@ -9,19 +9,25 @@ vignette: >
     %\VignetteEngine{knitr::rmarkdown}
     %\VignetteDepends{Cairo}
     %\VignetteEncoding{UTF-8}
-    \usepackage[utf8]{inputenc}        
+    \usepackage[utf8]{inputenc}
 ---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(eurostat)
+```
 
 # R Tools for Eurostat Open Data: maps
 
 This [rOpenGov](http://ropengov.github.io) R package provides tools to access [Eurostat database](http://ec.europa.eu/eurostat/data/database), which you can also browse on-line for the data sets and documentation. For contact information and source code, see the [package website](http://ropengov.github.io/eurostat/).
 
-
 See eurostat vignette for installation and basic use.
-
-```{r, echo=FALSE}
-library(eurostat)
-```
 
 ## Maps 
 

--- a/vignettes/articles/publications.Rmd
+++ b/vignettes/articles/publications.Rmd
@@ -1,17 +1,19 @@
 ---
 title: "Publications using the eurostat R package"
-date: "`r Sys.Date()`"
-output:
-  rmarkdown::html_vignette:
-    toc: true
+date: "2022-02-07"
+output: rmarkdown::html_vignette
 vignette: >
     %\VignetteIndexEntry{Publications using the eurostat R package}
     %\VignetteEngine{knitr::rmarkdown}
-    %\VignetteDepends{Cairo}
     %\VignetteEncoding{UTF-8}
-    \usepackage[utf8]{inputenc}    
 ---
 
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
 
 You can send us a note via the [issue tracker](https://github.com/rOpenGov/eurostat/issues) if you like to add a publication using the eurostat R package on this list:
 
@@ -24,4 +26,3 @@ package. R Journal 2017.
 External publications using the eurostat package:
 
  * Kenett RDS, Shmueli G. Information Quality: The Potential of Data and Analytics to Generate Knowledge. John Wiley & Sons, 2016.
-

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -3,24 +3,26 @@ title: "Vignette for the eurostat R package"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-    %\VignetteIndexEntry{Vignette for the eurostat R package}
-    %\VignetteEngine{knitr::rmarkdown}
-    %\VignetteEncoding{UTF-8}
-    \usepackage[utf8]{inputenc}
-editor_options:
-    chunk_output_type: console
+  %\VignetteIndexEntry{Vignette for the eurostat R package}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
-# R Tools for Eurostat Open Data
-
-This [rOpenGov](http://ropengov.github.io) R package provides tools to access [Eurostat database](https://ec.europa.eu/eurostat/data/database), which you can also browse on-line for the data sets and documentation. For contact information and source code, see the [package website](http://ropengov.github.io/eurostat/).
+```{r, include = FALSE}
+NOT_CRAN <- identical(tolower(Sys.getenv("NOT_CRAN")), "true")
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  purl = NOT_CRAN,
+  eval = NOT_CRAN
+)
+```
 
 ```{r setup, include=FALSE}
 # Global options
 library(knitr)
 # opts_chunk$set(fig.path="fig/")
 ```
-
 
 # Installation
 
@@ -34,13 +36,14 @@ install.packages("eurostat")
 Development version [(Github)](https://github.com/rOpenGov/eurostat):
 
 ```{r install2, eval=FALSE}
-library(devtools)
-install_github("ropengov/eurostat")
+library(remotes)
+remotes::install_github("ropengov/eurostat")
 ```
+
+Load the package:
 
 ```{r, echo=FALSE}
 library(eurostat)
 ```
 
-For examples on how to use the package, see the [online tutorial](http://ropengov.github.io/eurostat/) (Articles section of the homepage).
-
+For more detailed examples on how to use the package, see the [online tutorial](https://ropengov.github.io/eurostat/articles/articles/eurostat_tutorial.html).


### PR DESCRIPTION
Message from CRAN Team:

> 'Packages which use Internet resources should fail gracefully with an informative message
> if the resource is not available or has changed (and not give a check warning nor error).'

As CRAN tests are re-run regularly, I could not see what internet resource failure this message was exactly referring to. 

I did the following small fixes to the package:

- I ran package checks with Wi-Fi turned off and all NOTEs were related to checks not being able to resolve host in README, vignette, article URLs or checks not being able to access indices for different repositories. _So there should not be any problems with package examples or vignettes causing any problems._
- What was left to do was to double-check that problems with fickle internet resources were not accessed. Development version of the package has for a while had most vignettes turned into articles, as did CRAN version 3.7.5. Articles are now in `./vignettes/articles/` subfolder, not `./vignettes/website/`, to make the folder structure conform to the default setting in `usethis::use_article`.
- Articles themselves were checked for broken URLs and broken URLs were either removed or corrected.
- There is a NOTE in the current [eurostat check results page](https://cran.r-project.org/web/checks/check_results_eurostat.html) "Namespace in Imports field not imported from: ‘RColorBrewer’". Article maps.Rmd / "Map examples for the eurostat R package" uses this package in its example and therefore it should be retained. I have not been able to replicate this on my setup.

Tests have been run without any NOTEs, WARNINGs or ERRORs on `devtools::check_win_devel` and locally:

> R version 4.1.2 (2021-11-01)
> Platform: x86_64-apple-darwin17.0 (64-bit)
> Running under: macOS Monterey 12.2

For my part this package is ready for resubmission to CRAN.