### PR TITLE
fix typos and spelling errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,7 +203,7 @@
 * New `select_time` argument for `get_eurostat()` to select a time frequency  in case of multi-frequency datasets. Now the `get_eurostat()` also gives an error if you try to get multi-frequency with other time formats than `time_format = "raw"`. (#30) `time` column is also now in ascending order.
 * `get_eurostat()` gets a new argument `compress_file` to control compression of the cache file. Also cache filenames includes now all relevant arguments. (#28)
 * For `search_eurostat()` a new type option `type = "all"` to search all types.
-* For `label_eurostat()` new arguments. A `code` to retain also codes for spesified colums. A `eu_order` to order factor levels in Eurostat order, which uses the new function `dic_order()`. 
+* For `label_eurostat()` new arguments. A `code` to retain also codes for specified columns. A `eu_order` to order factor levels in Eurostat order, which uses the new function `dic_order()`. 
 * Now `label_eurostat_vars(x)` gives labels for names, if x is other than a character or a factor and `label_eurostat_tables(x)` does not accept other than a character or a factor.
 * For `get_eurostat()` a new argument `stringsAsFactors` to control the factor conversion of variables.
 * `eurotime2date` (and `get_eurostat`) convers now also daily data. 

--- a/revdep/library.noindex/eurostat/new/lubridate/NEWS.md
+++ b/revdep/library.noindex/eurostat/new/lubridate/NEWS.md
@@ -50,11 +50,11 @@ Version 1.9.0
 * [#1085](https://github.com/tidyverse/lubridate/issues/1085) `as_datetime()` now preserves the time zone of the POSIXt input.
 * [#1072](https://github.com/tidyverse/lubridate/issues/1072) Names are now handled correctly when combining multiple Period or Interval objects.
 * [#1003](https://github.com/tidyverse/lubridate/issues/1003) Correctly handle r and R formats in locales which have no p format
-* [#1074](https://github.com/tidyverse/lubridate/issues/1074) Fix concatination of named Period, Interval and Duration vectors.
+* [#1074](https://github.com/tidyverse/lubridate/issues/1074) Fix concatenation of named Period, Interval and Duration vectors.
 * [#1044](https://github.com/tidyverse/lubridate/issues/1044) POSIXlt results returned by `fast_strptime()` and `parse_date_time2()` now have a recycled `isdst` field.
 * [#1069](https://github.com/tidyverse/lubridate/issues/1069) Internal code handling the addition of period months and years no longer generates partially recycled POSIXlt objects.
 * Fix rounding of POSIXlt objects
-* [#1007](https://github.com/tidyverse/lubridate/issues/1007) Internal lubridate formats are no longer propagated to stamp formater.
+* [#1007](https://github.com/tidyverse/lubridate/issues/1007) Internal lubridate formats are no longer propagated to stamp formatter.
 * `train` argument in `parse_date_time` now takes effect. It was previously ignored.
 * [#1004](https://github.com/tidyverse/lubridate/issues/1004) Fix `c.POSIXct` and `c.Date` on empty single POSIXct and Date vectors.
 * [#1013](https://github.com/tidyverse/lubridate/issues/1013) Fix c(`POSIXct`,`POSIXlt`) heterogeneous concatenation.
@@ -267,7 +267,7 @@ Version 1.7.0
 * [#524](https://github.com/tidyverse/lubridate/pull/524) Correctly compute length of period in months (issue #490)
 * [#525](https://github.com/tidyverse/lubridate/pull/525) Fix to prevent `day<-`, `minute<-`, etc. from producing an error when length(x) is 0 (issue #517)
 * [#530](https://github.com/tidyverse/lubridate/issues/530) `parse_date_time` now throw warnings only for actual parsing errors (input with all NAs are silent)
-* [#534](https://github.com/tidyverse/lubridate/issues/534) Fix arithmetics with large numbers
+* [#534](https://github.com/tidyverse/lubridate/issues/534) Fix arithmetic with large numbers
 * [#554](https://github.com/tidyverse/lubridate/pull/554) Fix tests when running in non-English locales
 
 Version 1.6.0
@@ -295,7 +295,7 @@ Version 1.6.0
 ### CHANGES
 
 * Low letter specs for HMS (hms,hm,ms) in `parse_date_time` and related functions are now deprecated.
-* [#445](https://github.com/tidyverse/lubridate/issues/445) No more warning on occasional imprecise period length conversions. Imprecise arithmetics with periods is extensively documented.
+* [#445](https://github.com/tidyverse/lubridate/issues/445) No more warning on occasional imprecise period length conversions. Imprecise arithmetic with periods is extensively documented.
 * `pretty.*` family of functions were renamed and are no longer exported. If you need to use them, use `lubridate:::pretty_*` versions.
 * `change_on_boundary` argument in `ceiling_date` does not allow for global option anymore.
 * `as.duration`, `as.numeric` don't show "only estimate" messages on conversion from periods. The occasional approximate conversion is documented and deemed common knowledge.
@@ -314,7 +314,7 @@ Version 1.6.0
 * [#458](https://github.com/tidyverse/lubridate/issues/458) When year is missing in parsing, return consistently year 0.
 * [#448](https://github.com/tidyverse/lubridate/issues/448) Correctly handle missing months and days in C parser.
 * [#450](https://github.com/tidyverse/lubridate/issues/450) Fix incorrect handling of DST gaps in `date_decimal` and `decimal_date`.
-* [#420](https://github.com/tidyverse/lubridate/issues/420) `as.numeric` correctly converts periods to (aproximate) numeric time lengths.
+* [#420](https://github.com/tidyverse/lubridate/issues/420) `as.numeric` correctly converts periods to (approximate) numeric time lengths.
 
 Version 1.5.6
 ============
@@ -461,7 +461,7 @@ Version 1.3.0
 * lubridate parser functions now propagate NA's just as as.POSIXct, strptime and other functions do. Previously lubridate's parse functions would only return an error.
 * added [[ and [[<- methods for INterval, Period and Duration class objects
 * added `%m+%` and `%m-%` methods for Interval and Duration class objects that throw useful errors.
-* `olson_time_zones` retreives a character vector is Olson-style time zone names to use in lubridate
+* `olson_time_zones` retrieves a character vector is Olson-style time zone names to use in lubridate
 * summary methods for Interval, Period, and Duration classes
 * date_decimal converts a date written as a decimal of a year into a POSIXct date-time
 
@@ -471,7 +471,7 @@ Version 1.3.0
 * fixed bugs that created unintuitive results for `as.interval`, `int_overlaps`, `%within%` and the interval methods of `c`, `intersect`, `union`, `setdiff`, and `summary`.
 * parse functions, `as.interval`, `as.period` and `as.duration` now handlevectors of NA's without returning errors.
 * parsers better handle vectors of input that have more than 100 elements and many NAs
-* data frames that contain timespan objects with NAs in thme no longer fail toprint
+* data frames that contain timespan objects with NAs in them no longer fail toprint
 * `round_date`, `ceiling_date` and `update` now correctly handle input of length zero
 * `decimal_date` no longer returns NaN for first second of the year
 
@@ -617,7 +617,7 @@ as well as positive intervals. Intervals also now display with a time zone.
 allows modulo methods to be used with integer division in an intuitive manner,
 e.g. `a = a %/% b * b + a %% b`
 
-Users can still acheive a numerical result by using as.numeric() on input
+Users can still achieve a numerical result by using as.numeric() on input
 before performing modulo.
 
 * Periods, durations, and intervals can now all be put into a data frame.


### PR DESCRIPTION
Fixing some minor spelling errors which should not affect functionality but improve the overall quality of documentation.