### PR TITLE
update links to eurostat user-guide (v4.1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,7 +78,7 @@ downloading geospatial data (PR #264, thanks to @dieghernan):
 
 ## Major updates
 
-* Updated `get_eurostat()` and its assorted functions to download data from the new dissemination API (related to issues #251, #243). See Eurostat web page Transition - from Eurostat Bulk Download to API for a list of differences between old and new data sources: https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API
+* Updated `get_eurostat()` and its assorted functions to download data from the new dissemination API (related to issues #251, #243). See Eurostat web page Transition - from Eurostat Bulk Download to API for a list of differences between old and new data sources: https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload
 * Added new temporary functions for downloading and handling data from the new dissemination API: `get_eurostat_raw2`, `tidy_eurostat2`, `convert_time_col2`, `eurotime2date2`, `eurotime2num2` and `label_eurostat2`. When the old bulk download facilities are decommissioned, these functions will replace the old functions with old naming schemes (without the 2s at the end).
 * `tidy_eurostat2` function is now able to handle multiple time frequencies in one call: For example, you can download annual, quarterly, and monthly data simply by using a vector c("A", "Q", "M") in select_time instead of using these singular frequencies in separate calls. The function will also return multiple time series in one dataset if select_time is NULL (as it is by default). If the dataset contains multiple time series and these are explicitly downloaded / no select_time parameter is given, a message will be printed.
 * `eurotime2num` can now handle monthly and weekly data as well.
@@ -90,7 +90,7 @@ downloading geospatial data (PR #264, thanks to @dieghernan):
 
 # eurostat 3.7.13 (2023-02-01)
 
-* Updated `get_eurostat_json()` to migrate from JSON web service to API Statistics (addressed in issues #243, #251). Please note that the output from JSON API is now slightly different than before: the datasets now contain a freq column to indicate the frequency with which data has been collected, for example annually "A", monthly "M" or quarterly "Q". See Eurostat - Data browser online help website for more information: https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+migrating+from+JSON+web+service+to+API+Statistics
+* Updated `get_eurostat_json()` to migrate from JSON web service to API Statistics (addressed in issues #243, #251). Please note that the output from JSON API is now slightly different than before: the datasets now contain a freq column to indicate the frequency with which data has been collected, for example annually "A", monthly "M" or quarterly "Q". See Eurostat - Data browser online help website for more information: https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/json
 * Minor fixes in `get_bibentry()` and `get_eurostat_geospatial()`
 
 # eurostat 3.7.12 (2022-06-28)

--- a/R/eurostat-package.R
+++ b/R/eurostat-package.R
@@ -50,7 +50,7 @@
 #' Data is downloaded from Eurostat SDMX 2.1 API endpoint 
 #' as compressed TSV files that are transformed into tabular format.
 #' See Eurostat documentation for more information:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+query}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Dataquery}
 #' 
 #' The new dissemination API replaces the old bulk download facility that was 
 #' used by Eurostat before October 2023 and by the eurostat R package versions 
@@ -58,7 +58,7 @@
 #' See Eurostat documentation about the transition from Bulk Download to API
 #' for more information about the differences between the old bulk download 
 #' facility and the data provided by the new API connection:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload}
 #' 
 #' See especially the document Migrating_to_API_TSV.pdf that describes the 
 #' changes in TSV file format in new applications.
@@ -75,20 +75,20 @@
 #' Eurostat. We may support this feature in the future. In the meantime, if you
 #' are interested in filtering Dissemination API data queries manually, please
 #' consult the following Eurostat documentation:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+filtering}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Filteringonseries-keys}
 #' 
 #' # Data source: Eurostat API Statistics (JSON API)
 #' 
 #' Data is downloaded from Eurostat API Statistics. See Eurostat documentation
 #' for more information about data queries in API Statistics
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api}
 #' 
 #' This replaces the old JSON Web Services that was used by Eurostat before
 #' February 2023 and by the eurostat R package versions before 3.7.13.
 #' See Eurostat documentation about the migration from JSON web service to API
 #' Statistics for more information about the differences between the old and
 #' the new service:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+migrating+from+JSON+web+service+to+API+Statistics}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/json}
 #' 
 #' For easily viewing which filtering options are available -  in addition to
 #' the default ones, time and language - Eurostat Web services Query builder 
@@ -182,7 +182,7 @@
 #' 
 #' For more information about data filtering see Eurostat documentation
 #' on API Statistics:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
 #' 
 #' # Data source: Eurostat Table of Contents
 #' 
@@ -193,7 +193,7 @@
 #' \url{https://ec.europa.eu/eurostat/api/dissemination/catalogue/toc/txt?lang=de}
 #' 
 #' See Eurostat documentation on TOC items:
-#' \url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+-+Detailed+guidelines+-+Catalogue+API+-+TOC}
+#' \url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-detailed-guidelines/catalogue-api/toc}
 #' 
 #' # Data source: GISCO - General Copyright
 #' 

--- a/R/get_eurostat.R
+++ b/R/get_eurostat.R
@@ -83,9 +83,9 @@
 #' 
 #' @details
 #' Datasets are downloaded from
-#' [the Eurostat SDMX 2.1 API](https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API)
+#' [the Eurostat SDMX 2.1 API](https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload)
 #' in TSV format or from The Eurostat
-#' [API Statistics JSON API](https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query).
+#' [API Statistics JSON API](https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api).
 #' If only the table `id` is given, the whole table is downloaded from the
 #' SDMX API. If any `filters` are given JSON API is used instead.
 #'

--- a/man/eurostat-package.Rd
+++ b/man/eurostat-package.Rd
@@ -39,7 +39,7 @@ the data."
 Data is downloaded from Eurostat SDMX 2.1 API endpoint
 as compressed TSV files that are transformed into tabular format.
 See Eurostat documentation for more information:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+query}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Dataquery}
 
 The new dissemination API replaces the old bulk download facility that was
 used by Eurostat before October 2023 and by the eurostat R package versions
@@ -47,7 +47,7 @@ before 4.0.0.
 See Eurostat documentation about the transition from Bulk Download to API
 for more information about the differences between the old bulk download
 facility and the data provided by the new API connection:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload}
 
 See especially the document Migrating_to_API_TSV.pdf that describes the
 changes in TSV file format in new applications.
@@ -64,20 +64,20 @@ datasets downloaded through the SDMX Dissemination API is also supported by
 Eurostat. We may support this feature in the future. In the meantime, if you
 are interested in filtering Dissemination API data queries manually, please
 consult the following Eurostat documentation:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+filtering}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Filteringonseries-keys}
 }
 
 \section{Data source: Eurostat API Statistics (JSON API)}{
 Data is downloaded from Eurostat API Statistics. See Eurostat documentation
 for more information about data queries in API Statistics
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api}
 
 This replaces the old JSON Web Services that was used by Eurostat before
 February 2023 and by the eurostat R package versions before 3.7.13.
 See Eurostat documentation about the migration from JSON web service to API
 Statistics for more information about the differences between the old and
 the new service:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+migrating+from+JSON+web+service+to+API+Statistics}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/json}
 
 For easily viewing which filtering options are available -  in addition to
 the default ones, time and language - Eurostat Web services Query builder
@@ -179,7 +179,7 @@ Example:
 
 For more information about data filtering see Eurostat documentation
 on API Statistics:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api#APIGettingstartedwithstatisticsAPI-Filterdata}
 }
 }
 
@@ -191,7 +191,7 @@ The Eurostat Table of Contents (TOC) is downloaded from
 \url{https://ec.europa.eu/eurostat/api/dissemination/catalogue/toc/txt?lang=de}
 
 See Eurostat documentation on TOC items:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+-+Detailed+guidelines+-+Catalogue+API+-+TOC}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-detailed-guidelines/catalogue-api/toc}
 }
 
 \section{Data source: GISCO - General Copyright}{

--- a/man/get_eurostat.Rd
+++ b/man/get_eurostat.Rd
@@ -113,9 +113,9 @@ Download data sets from Eurostat \url{https://ec.europa.eu/eurostat}
 }
 \details{
 Datasets are downloaded from
-\href{https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API}{the Eurostat SDMX 2.1 API}
+\href{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload}{the Eurostat SDMX 2.1 API}
 in TSV format or from The Eurostat
-\href{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query}{API Statistics JSON API}.
+\href{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api}{API Statistics JSON API}.
 If only the table \code{id} is given, the whole table is downloaded from the
 SDMX API. If any \code{filters} are given JSON API is used instead.
 
@@ -257,7 +257,7 @@ Example:
 
 For more information about data filtering see Eurostat documentation
 on API Statistics:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
 }
 }
 
@@ -295,7 +295,7 @@ datasets downloaded through the SDMX Dissemination API is also supported by
 Eurostat. We may support this feature in the future. In the meantime, if you
 are interested in filtering Dissemination API data queries manually, please
 consult the following Eurostat documentation:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+filtering}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Filteringonseries-keys}
 }
 
 \section{Strategies for handling large datasets more efficiently}{

--- a/man/get_eurostat_folder.Rd
+++ b/man/get_eurostat_folder.Rd
@@ -36,14 +36,14 @@ The Eurostat Table of Contents (TOC) is downloaded from
 \url{https://ec.europa.eu/eurostat/api/dissemination/catalogue/toc/txt?lang=de}
 
 See Eurostat documentation on TOC items:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+-+Detailed+guidelines+-+Catalogue+API+-+TOC}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-detailed-guidelines/catalogue-api/toc}
 }
 
 \section{Data source: Eurostat SDMX 2.1 Dissemination API}{
 Data is downloaded from Eurostat SDMX 2.1 API endpoint
 as compressed TSV files that are transformed into tabular format.
 See Eurostat documentation for more information:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+query}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Dataquery}
 
 The new dissemination API replaces the old bulk download facility that was
 used by Eurostat before October 2023 and by the eurostat R package versions
@@ -51,7 +51,7 @@ before 4.0.0.
 See Eurostat documentation about the transition from Bulk Download to API
 for more information about the differences between the old bulk download
 facility and the data provided by the new API connection:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload}
 
 See especially the document Migrating_to_API_TSV.pdf that describes the
 changes in TSV file format in new applications.

--- a/man/get_eurostat_json.Rd
+++ b/man/get_eurostat_json.Rd
@@ -104,14 +104,14 @@ in the Eurostat website. We hope you never encounter them.
 \section{Data source: Eurostat API Statistics (JSON API)}{
 Data is downloaded from Eurostat API Statistics. See Eurostat documentation
 for more information about data queries in API Statistics
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api}
 
 This replaces the old JSON Web Services that was used by Eurostat before
 February 2023 and by the eurostat R package versions before 3.7.13.
 See Eurostat documentation about the migration from JSON web service to API
 Statistics for more information about the differences between the old and
 the new service:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+migrating+from+JSON+web+service+to+API+Statistics}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/json}
 
 For easily viewing which filtering options are available -  in addition to
 the default ones, time and language - Eurostat Web services Query builder
@@ -213,7 +213,7 @@ Example:
 
 For more information about data filtering see Eurostat documentation
 on API Statistics:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+Statistics+-+data+query#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/api#APIStatisticsdataquery-TheparametersdefinedintheRESTrequest}
 }
 }
 
@@ -273,7 +273,7 @@ datasets downloaded through the SDMX Dissemination API is also supported by
 Eurostat. We may support this feature in the future. In the meantime, if you
 are interested in filtering Dissemination API data queries manually, please
 consult the following Eurostat documentation:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+filtering}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Filteringonseries-keys}
 }
 
 \examples{

--- a/man/get_eurostat_raw.Rd
+++ b/man/get_eurostat_raw.Rd
@@ -29,7 +29,7 @@ dissemination API.
 Data is downloaded from Eurostat SDMX 2.1 API endpoint
 as compressed TSV files that are transformed into tabular format.
 See Eurostat documentation for more information:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+query}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Dataquery}
 
 The new dissemination API replaces the old bulk download facility that was
 used by Eurostat before October 2023 and by the eurostat R package versions
@@ -37,7 +37,7 @@ before 4.0.0.
 See Eurostat documentation about the transition from Bulk Download to API
 for more information about the differences between the old bulk download
 facility and the data provided by the new API connection:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/Transition+-+from+Eurostat+Bulk+Download+to+API}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-migrating/bulkdownload}
 
 See especially the document Migrating_to_API_TSV.pdf that describes the
 changes in TSV file format in new applications.
@@ -103,7 +103,7 @@ datasets downloaded through the SDMX Dissemination API is also supported by
 Eurostat. We may support this feature in the future. In the meantime, if you
 are interested in filtering Dissemination API data queries manually, please
 consult the following Eurostat documentation:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+data+filtering}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Filteringonseries-keys}
 }
 
 \examples{

--- a/man/get_eurostat_toc.Rd
+++ b/man/get_eurostat_toc.Rd
@@ -49,7 +49,7 @@ The Eurostat Table of Contents (TOC) is downloaded from
 \url{https://ec.europa.eu/eurostat/api/dissemination/catalogue/toc/txt?lang=de}
 
 See Eurostat documentation on TOC items:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+-+Detailed+guidelines+-+Catalogue+API+-+TOC}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-detailed-guidelines/catalogue-api/toc}
 }
 
 \examples{

--- a/man/search_eurostat.Rd
+++ b/man/search_eurostat.Rd
@@ -74,7 +74,7 @@ The Eurostat Table of Contents (TOC) is downloaded from
 \url{https://ec.europa.eu/eurostat/api/dissemination/catalogue/toc/txt?lang=de}
 
 See Eurostat documentation on TOC items:
-\url{https://wikis.ec.europa.eu/display/EUROSTATHELP/API+-+Detailed+guidelines+-+Catalogue+API+-+TOC}
+\url{https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-detailed-guidelines/catalogue-api/toc}
 }
 
 \examples{

--- a/vignettes/articles/dimlst_vs_allconceptschemes.Rmd
+++ b/vignettes/articles/dimlst_vs_allconceptschemes.Rmd
@@ -32,7 +32,7 @@ AGECHILD	Age of the child
 AGEDEF	Age definition
 ```
 
-An example of the new Concept Scheme file for dataset `NAMA_10_GDP` (see instructions for downloading [here](https://wikis.ec.europa.eu/display/EUROSTATHELP/API+SDMX+2.1+-+metadata+query#APISDMX2.1metadataquery-SDMX2.1endpoint-REST-SDMX-ML2.1ConceptScheme)):
+An example of the new Concept Scheme file for dataset `NAMA_10_GDP` (see instructions for downloading [here](https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-getting-started/sdmx2.1#APIGettingstartedwithSDMX2.1API-Lookingupinthemetadataofadataset)):
 
 ```{xml}
 <s:Concept id="freq" urn="urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=ESTAT:NAMA_10_GDP(45.0).freq">


### PR DESCRIPTION
The links to https://wikis.ec.europa.eu/display/EUROSTATHELP/ seem dead.
As similar content is available at https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access
I suppose the content was moved